### PR TITLE
⚡ Bolt: Remove N+1 query problem in product filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-02 - N+1 Query bottlenecks in product filtering
+**Learning:** Found an N+1 query performance bottleneck in `server/controllers/product.controller.js` when filtering by `minRating`. The previous logic loaded all matching products, then looped over them using `Promise.all` to query the `reviews` table separately for each product's average rating.
+**Action:** Replaced the application-level filtering with a SQL subquery. Instead of fetching reviews in a loop, wrapped the primary count query inside a derived table (subquery) that calculates the average rating and applies `HAVING average_rating >= ?` logic directly in the database.

--- a/server/controllers/product.controller.js
+++ b/server/controllers/product.controller.js
@@ -66,32 +66,31 @@ exports.getAllProducts = async (req, res) => {
     const [products] = await pool.query(query, params);
     
     // Build count query with the same conditions
-    let countQuery = `
-      SELECT COUNT(*) as total 
-      FROM products p
-      WHERE ${conditions.join(' AND ')}
-    `;
-    
     let countParams = [...params.slice(0, params.length - 2)]; // Remove limit and offset
+    let countQuery;
+
+    if (minRating !== null) {
+      // Use subquery to count products that meet the rating criteria efficiently
+      countQuery = `
+        SELECT COUNT(*) as total FROM (
+          SELECT p.id, (SELECT AVG(rating) FROM reviews r WHERE r.product_id = p.id) as average_rating
+          FROM products p
+          WHERE ${conditions.join(' AND ')}
+          HAVING average_rating >= ?
+        ) as subquery
+      `;
+      countParams.push(minRating);
+    } else {
+      countQuery = `
+        SELECT COUNT(*) as total
+        FROM products p
+        WHERE ${conditions.join(' AND ')}
+      `;
+    }
     
     // Execute count query
     const [countResult] = await pool.query(countQuery, countParams);
-    
-    // If we have a rating filter, we need to count manually
     let totalProducts = countResult[0].total;
-    
-    if (minRating !== null) {
-      // Count products that meet the rating criteria
-      const filteredProducts = await Promise.all(products.map(async (product) => {
-        const [ratingResult] = await pool.query(
-          'SELECT AVG(rating) as avg_rating FROM reviews WHERE product_id = ?',
-          [product.id]
-        );
-        return ratingResult[0].avg_rating >= minRating ? product : null;
-      }));
-      
-      totalProducts = filteredProducts.filter(p => p !== null).length;
-    }
     
     const totalPages = Math.ceil(totalProducts / limit);
     
@@ -226,32 +225,31 @@ exports.getProductsByCategory = async (req, res) => {
     const [products] = await pool.query(query, params);
     
     // Build count query with the same conditions
-    let countQuery = `
-      SELECT COUNT(*) as total 
-      FROM products p
-      WHERE ${conditions.join(' AND ')}
-    `;
-    
     let countParams = [...params.slice(0, params.length - 2)]; // Remove limit and offset
+    let countQuery;
+
+    if (minRating !== null) {
+      // Use subquery to count products that meet the rating criteria efficiently
+      countQuery = `
+        SELECT COUNT(*) as total FROM (
+          SELECT p.id, (SELECT AVG(rating) FROM reviews r WHERE r.product_id = p.id) as average_rating
+          FROM products p
+          WHERE ${conditions.join(' AND ')}
+          HAVING average_rating >= ?
+        ) as subquery
+      `;
+      countParams.push(minRating);
+    } else {
+      countQuery = `
+        SELECT COUNT(*) as total
+        FROM products p
+        WHERE ${conditions.join(' AND ')}
+      `;
+    }
     
     // Execute count query
     const [countResult] = await pool.query(countQuery, countParams);
-    
-    // If we have a rating filter, we need to count manually
     let totalProducts = countResult[0].total;
-    
-    if (minRating !== null) {
-      // Count products that meet the rating criteria
-      const filteredProducts = await Promise.all(products.map(async (product) => {
-        const [ratingResult] = await pool.query(
-          'SELECT AVG(rating) as avg_rating FROM reviews WHERE product_id = ?',
-          [product.id]
-        );
-        return ratingResult[0].avg_rating >= minRating ? product : null;
-      }));
-      
-      totalProducts = filteredProducts.filter(p => p !== null).length;
-    }
     
     const totalPages = Math.ceil(totalProducts / limit);
     
@@ -347,33 +345,33 @@ exports.searchProducts = async (req, res) => {
     const [products] = await pool.query(query, params);
     
     // Build count query with the same conditions
-    let countQuery = `
-      SELECT COUNT(*) as total 
-      FROM products p
-      LEFT JOIN categories c ON p.category_id = c.id
-      WHERE ${conditions.join(' AND ')}
-    `;
-    
     let countParams = [...params.slice(0, params.length - 2)]; // Remove limit and offset
+    let countQuery;
+
+    if (minRating !== null) {
+      // Use subquery to count products that meet the rating criteria efficiently
+      countQuery = `
+        SELECT COUNT(*) as total FROM (
+          SELECT p.id, (SELECT AVG(rating) FROM reviews r WHERE r.product_id = p.id) as average_rating
+          FROM products p
+          LEFT JOIN categories c ON p.category_id = c.id
+          WHERE ${conditions.join(' AND ')}
+          HAVING average_rating >= ?
+        ) as subquery
+      `;
+      countParams.push(minRating);
+    } else {
+      countQuery = `
+        SELECT COUNT(*) as total
+        FROM products p
+        LEFT JOIN categories c ON p.category_id = c.id
+        WHERE ${conditions.join(' AND ')}
+      `;
+    }
     
     // Execute count query
     const [countResult] = await pool.query(countQuery, countParams);
-    
-    // If we have a rating filter, we need to count manually
     let totalProducts = countResult[0].total;
-    
-    if (minRating !== null) {
-      // Count products that meet the rating criteria
-      const filteredProducts = await Promise.all(products.map(async (product) => {
-        const [ratingResult] = await pool.query(
-          'SELECT AVG(rating) as avg_rating FROM reviews WHERE product_id = ?',
-          [product.id]
-        );
-        return ratingResult[0].avg_rating >= minRating ? product : null;
-      }));
-      
-      totalProducts = filteredProducts.filter(p => p !== null).length;
-    }
     
     const totalPages = Math.ceil(totalProducts / limit);
     


### PR DESCRIPTION
💡 What: Removed N+1 query bottleneck in `getAllProducts`, `getProductsByCategory`, and `searchProducts`.
🎯 Why: When calculating total products with a `minRating` filter, the app previously fetched all matching products and used `Promise.all` to execute a separate SQL query per product for its average rating, significantly degrading performance.
📊 Impact: Reduces database calls from N+1 to 1 query when filtering by minimum rating. Will significantly decrease time-to-first-byte and reduce load on the database.
🔬 Measurement: Verify by executing a products search or category listing query with `min_rating` filter parameter and check query execution logs.

---
*PR created automatically by Jules for task [1654749280729344524](https://jules.google.com/task/1654749280729344524) started by @jeanzinho509*