### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in image deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Path Traversal in File Deletion
+**Vulnerability:** The `deleteImage` API endpoint constructed file deletion paths directly from user input (`req.body.imageUrl`) without path normalization and validation, allowing path traversal attacks (e.g. `imageUrl: "/uploads/../../package.json"`).
+**Learning:** Node.js `path.join()` resolves relative segments like `..` but doesn't prevent paths from escaping the intended root directory. Checking if a path is safe requires resolving absolute paths and comparing string prefixes.
+**Prevention:** Always use `path.resolve()` to get absolute paths and ensure the targeted file path `startsWith(resolvedBaseDir + path.sep)` to restrict file operations to the intended directory.

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -160,13 +160,22 @@ exports.deleteImage = async (req, res) => {
     const urlPath = imageUrl.replace('/uploads/', '');
     const filePath = path.join(UPLOAD_DIR, urlPath);
     
+    // 🛡️ SECURITY: Prevent path traversal by ensuring the resolved path is inside UPLOAD_DIR
+    const resolvedPath = path.resolve(filePath);
+    const resolvedUploadDir = path.resolve(UPLOAD_DIR);
+
+    if (!resolvedPath.startsWith(resolvedUploadDir + path.sep)) {
+      console.warn(`[SECURITY] Path traversal attempt detected: ${imageUrl}`);
+      return res.status(403).json({ message: 'Forbidden: Invalid file path' });
+    }
+
     // Check if file exists
-    if (!fs.existsSync(filePath)) {
+    if (!fs.existsSync(resolvedPath)) {
       return res.status(404).json({ message: 'Image not found' });
     }
     
     // Delete file
-    fs.unlinkSync(filePath);
+    fs.unlinkSync(resolvedPath);
     
     res.status(200).json({
       message: 'Image deleted successfully'


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `deleteImage` API endpoint in `server/controllers/upload.controller.js` previously constructed file deletion paths directly from user input (`req.body.imageUrl`). Because it used `path.join` without absolute path validation, it was vulnerable to path traversal attacks (e.g. `imageUrl: "/uploads/../../package.json"`).
🎯 Impact: Attackers could delete arbitrary files on the server using `..` directory traversal sequences.
🔧 Fix: Resolved both the requested path and the base upload directory. Added a check `resolvedPath.startsWith(resolvedUploadDir + path.sep)` to ensure the requested path is strictly within the boundaries of the `uploads` directory. Handled violations by returning a 403 Forbidden.
✅ Verification: Tested the exploit logic via a local node script, confirming that traversing out of the directory triggers a 403, while correctly structured internal paths resolve correctly and complete the deletion.

---
*PR created automatically by Jules for task [4363788664655958488](https://jules.google.com/task/4363788664655958488) started by @jeanzinho509*