### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in image deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2023-10-24 - Path Traversal in Image Deletion
+**Vulnerability:** The `deleteImage` endpoint in `upload.controller.js` directly appended user-supplied `imageUrl` to the base upload directory using `path.join()`. This allowed attackers to use directory traversal sequences (like `../../../../etc/passwd`) to delete arbitrary files on the server.
+**Learning:** `path.join()` resolves `..` sequences but does not restrict the resulting path to the base directory. It's insufficient for secure path handling of user inputs.
+**Prevention:** Always use `path.resolve()` on both the base directory and the target file path. Verify that the resolved target path `startsWith(resolvedBaseDir + path.sep)` to prevent both directory traversal and partial directory name matching attacks.

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -160,6 +160,14 @@ exports.deleteImage = async (req, res) => {
     const urlPath = imageUrl.replace('/uploads/', '');
     const filePath = path.join(UPLOAD_DIR, urlPath);
     
+    // Security check: prevent path traversal
+    const resolvedPath = path.resolve(filePath);
+    const resolvedUploadDir = path.resolve(UPLOAD_DIR);
+
+    if (!resolvedPath.startsWith(resolvedUploadDir + path.sep) && resolvedPath !== resolvedUploadDir) {
+      return res.status(403).json({ message: 'Forbidden: Invalid file path' });
+    }
+
     // Check if file exists
     if (!fs.existsSync(filePath)) {
       return res.status(404).json({ message: 'Image not found' });


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `deleteImage` endpoint in `server/controllers/upload.controller.js` was vulnerable to Directory/Path Traversal. It used user-supplied `imageUrl` with `path.join()` without verifying the final boundary.
🎯 Impact: An authenticated attacker could delete arbitrary files on the server (e.g., `../../../../etc/passwd`) by manipulating the `imageUrl` parameter.
🔧 Fix: Used `path.resolve()` to get the absolute paths for both the target file and the base upload directory. Added a check `resolvedPath.startsWith(resolvedUploadDir + path.sep)` to ensure the target file is strictly within the allowed directory, preventing traversal and partial directory name matches.
✅ Verification: Tested via unit test script that attempting to access paths containing `..` or outside the upload directory returns a `403 Forbidden` response.

---
*PR created automatically by Jules for task [828749007500439113](https://jules.google.com/task/828749007500439113) started by @jeanzinho509*