### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Image Deletion Endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-13 - [Fix Path Traversal in File Deletion]
+**Vulnerability:** Path Traversal (CWE-22) in `upload.controller.js` `deleteImage` endpoint allowing deletion of arbitrary files on the server by supplying path traversal characters (e.g., `../../`) in the `imageUrl` parameter.
+**Learning:** `path.join` does not prevent directory traversal if the user-controlled input contains `../`. Simply appending it to a base directory allows it to resolve outside the intended folder.
+**Prevention:** Always use `path.resolve` to get the absolute path of the target, and then enforce that the resolved path strictly starts with the absolute path of the base directory plus a path separator.

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -158,7 +158,13 @@ exports.deleteImage = async (req, res) => {
     
     // Extract file path from URL
     const urlPath = imageUrl.replace('/uploads/', '');
-    const filePath = path.join(UPLOAD_DIR, urlPath);
+    const filePath = path.resolve(UPLOAD_DIR, urlPath);
+    const absoluteUploadDir = path.resolve(UPLOAD_DIR);
+
+    // Prevent path traversal attacks
+    if (!filePath.startsWith(absoluteUploadDir + path.sep)) {
+      return res.status(403).json({ message: 'Forbidden: Invalid image path' });
+    }
     
     // Check if file exists
     if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path Traversal (CWE-22) in the `deleteImage` endpoint (`server/controllers/upload.controller.js`). The endpoint extracted a file path from user input and joined it with the upload directory base. However, `path.join` does not prevent traversing out of the base directory if `../` sequences are present.
🎯 **Impact:** An authenticated attacker could supply an `imageUrl` containing path traversal characters to arbitrarily delete any file on the host filesystem that the Node process has permissions to delete.
🔧 **Fix:** Replaced `path.join` with `path.resolve` to calculate the absolute path and explicitly verify that the resolved path starts with the absolute directory of the uploads folder. Added Sentinel journal entry in `.jules/sentinel.md`.
✅ **Verification:** Verified by requesting code review which passed, verifying the path traversal payload is blocked and the file logic correctly protects the server boundaries.

---
*PR created automatically by Jules for task [16070970432933689789](https://jules.google.com/task/16070970432933689789) started by @jeanzinho509*