### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in image deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Path Traversal in Image Deletion
+**Vulnerability:** Path traversal vulnerability in `server/controllers/upload.controller.js`'s `deleteImage` function.
+**Learning:** `imageUrl` from `req.body` is used to construct `filePath` without validation. `imageUrl.replace('/uploads/', '')` does not prevent directory traversal if the path contains `../`. An attacker could pass `imageUrl: "/uploads/../../server.js"` and delete arbitrary files.
+**Prevention:** Properly resolve the target path and validate that it starts with the intended base upload directory.

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -158,7 +158,12 @@ exports.deleteImage = async (req, res) => {
     
     // Extract file path from URL
     const urlPath = imageUrl.replace('/uploads/', '');
-    const filePath = path.join(UPLOAD_DIR, urlPath);
+    const filePath = path.resolve(UPLOAD_DIR, urlPath);
+
+    // Validate path to prevent path traversal
+    if (!filePath.startsWith(path.resolve(UPLOAD_DIR) + path.sep)) {
+      return res.status(403).json({ message: 'Forbidden: Invalid path' });
+    }
     
     // Check if file exists
     if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal vulnerability in `deleteImage` function in `server/controllers/upload.controller.js`. The `imageUrl` from `req.body` was used to construct the deletion path without proper validation, allowing attackers to delete arbitrary files on the server using `../`.
🎯 Impact: An attacker could potentially delete critical system files, application source code, or other users' data, leading to a denial of service or data loss.
🔧 Fix: Resolved the constructed path using `path.resolve` and validated that it strictly starts with the base `UPLOAD_DIR` (including the path separator to prevent directory name bypasses). Invalid paths now return a `403 Forbidden` response.
✅ Verification: Tested locally by mocking request objects. Normal file deletions return 404 (as intended when testing missing files), while malicious inputs containing `../` correctly return 403.

---
*PR created automatically by Jules for task [13163830750584968521](https://jules.google.com/task/13163830750584968521) started by @jeanzinho509*