### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Privilege Escalation in Registration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - Privilege Escalation via Mass Assignment in Registration
+**Vulnerability:** The public registration endpoint (`/register` in `server/controllers/auth.controller.js`) directly extracted the `role` field from the client's HTTP request body and assigned it to the newly created user in the database.
+**Learning:** This is a classic "Mass Assignment" or "Privilege Escalation" vulnerability. Because there was no server-side validation or stripping of the `role` field, a malicious user could craft a request payload like `{"name": "Attacker", "email": "attacker@example.com", "password": "password", "role": "admin"}` and successfully register an administrator account, bypassing all intended access controls. Never trust user input to define their own privilege levels.
+**Prevention:** Explicitly define and restrict the fields that can be assigned from user input. For registration, the role should always be hardcoded to the lowest privilege level (e.g., `'user'`). Privilege elevation should be handled in a separate, secure endpoint that requires administrative authorization.

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -20,7 +20,9 @@ const sendPasswordResetEmail = (email, token) => {
 // Register a new user
 exports.register = async (req, res) => {
   try {
-    const { name, email, password, phone, role } = req.body;
+    // 🛡️ SECURITY FIX: Removed 'role' from destructuring to prevent Privilege Escalation
+    // Attackers could pass {"role": "admin"} to gain admin access
+    const { name, email, password, phone } = req.body;
     
     // Validate input
     if (!name || !email || !password) {
@@ -38,8 +40,9 @@ exports.register = async (req, res) => {
     const salt = await bcrypt.genSalt(10);
     const hashedPassword = await bcrypt.hash(password, salt);
     
-    // Set default role to 'user' unless specified and user is authorized
-    const userRole = role || 'user';
+    // 🛡️ SECURITY FIX: Force user role to 'user'
+    // Privilege escalation prevention: Never trust client-provided roles
+    const userRole = 'user';
     
     // Insert user into database
     const [result] = await pool.query(


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The public `/register` endpoint directly extracted the `role` field from the client's HTTP request body and assigned it to the newly created user in the database without any authorization check or sanitization.
🎯 Impact: A malicious user could craft a request payload like `{"name": "Attacker", "email": "a@a.com", "password": "pass", "role": "admin"}` and successfully register an administrator account, bypassing all intended access controls and taking over the application.
🔧 Fix: Removed `role` from the destructured `req.body` variables and hardcoded the default `userRole` to `'user'`.
✅ Verification: Review the code to ensure `req.body.role` is ignored and the inserted role is forced to 'user'.

---
*PR created automatically by Jules for task [547403249653744049](https://jules.google.com/task/547403249653744049) started by @jeanzinho509*