### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Image Deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-21 - [CRITICAL] Fix Path Traversal in Image Deletion
+**Vulnerability:** The `deleteImage` endpoint in `server/controllers/upload.controller.js` used `path.join(UPLOAD_DIR, urlPath)` directly with user-supplied `imageUrl` input, allowing attackers to delete any file on the server (e.g., `../../.env` or `../../server.js`) via Path Traversal (CWE-22).
+**Learning:** `path.join` does not prevent traversing upwards with `../`. If user input controls the path, `path.resolve` must be used, and the resulting absolute path must be explicitly checked against the allowed base directory.
+**Prevention:** Always use `path.resolve()` alongside a containment check (e.g., `if (!filePath.startsWith(resolvedUploadDir + path.sep))`) whenever building file system paths using user input.

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -158,7 +158,13 @@ exports.deleteImage = async (req, res) => {
     
     // Extract file path from URL
     const urlPath = imageUrl.replace('/uploads/', '');
-    const filePath = path.join(UPLOAD_DIR, urlPath);
+    const filePath = path.resolve(UPLOAD_DIR, urlPath);
+
+    // Security check: Prevent path traversal
+    const resolvedUploadDir = path.resolve(UPLOAD_DIR);
+    if (!filePath.startsWith(resolvedUploadDir + path.sep)) {
+      return res.status(403).json({ message: 'Forbidden: Invalid file path' });
+    }
     
     // Check if file exists
     if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `deleteImage` endpoint in `server/controllers/upload.controller.js` used `path.join(UPLOAD_DIR, urlPath)` directly with user-supplied `imageUrl` input, allowing attackers to perform Path Traversal (CWE-22) and target sensitive server files for deletion.
🎯 Impact: Attackers could potentially delete any file accessible by the application's process on the server (e.g. `.env`, `.gitignore`, `.js` files), causing severe disruptions or system damage.
🔧 Fix: Updated the endpoint to securely resolve the destination path using `path.resolve()` and verify that the resulting file path begins explicitly with the intended `UPLOAD_DIR` base directory via a prefix containment check.
✅ Verification: Review the code to ensure `filePath.startsWith(resolvedUploadDir + path.sep)` returns `false` if `urlPath` climbs out of the designated directory.

---
*PR created automatically by Jules for task [12824000555905219040](https://jules.google.com/task/12824000555905219040) started by @jeanzinho509*