### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Mass Assignment in User Registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+pnpm-lock.yaml

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [Mass Assignment Privilege Escalation in User Registration]
+**Vulnerability:** The `/api/auth/register` endpoint destructured `role` from the request body (`req.body`) and directly applied it to the database insert statement if provided. This allowed any unauthenticated user to register an account with `'admin'` or `'seller'` roles simply by supplying `"role": "admin"` in the JSON payload.
+**Learning:** This existed because the role was conditionally assigned with `role || 'user'`, meant to allow admins to create other roles but insecurely implemented within the public registration flow.
+**Prevention:** Never extract authorization-level fields (e.g. roles, permissions, administrative flags) from an untrusted request payload unless performing strict validation/authorization checks first. For public registration, always hardcode the default user privilege level (e.g. `'user'`).

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -20,7 +20,8 @@ const sendPasswordResetEmail = (email, token) => {
 // Register a new user
 exports.register = async (req, res) => {
   try {
-    const { name, email, password, phone, role } = req.body;
+    // SECURITY FIX: Removed 'role' from destructured req.body to prevent mass assignment/privilege escalation.
+    const { name, email, password, phone } = req.body;
     
     // Validate input
     if (!name || !email || !password) {
@@ -38,8 +39,8 @@ exports.register = async (req, res) => {
     const salt = await bcrypt.genSalt(10);
     const hashedPassword = await bcrypt.hash(password, salt);
     
-    // Set default role to 'user' unless specified and user is authorized
-    const userRole = role || 'user';
+    // SECURITY FIX: Hardcode role to 'user' to prevent privilege escalation via registration.
+    const userRole = 'user';
     
     // Insert user into database
     const [result] = await pool.query(


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Mass Assignment / Privilege Escalation. The `/api/auth/register` endpoint destructured `role` from `req.body` and allowed it to be applied to the database insert statement. 
🎯 Impact: Any unauthenticated user could create an account with `admin` or `seller` roles simply by providing `{"role": "admin"}` in the registration payload, fully compromising the system.
🔧 Fix: Removed `role` from the destructured payload and hardcoded the default user privilege level to `user` in `auth.controller.js`. Added a learning record to `.jules/sentinel.md`.
✅ Verification: Ran a curl request posting `{"role": "admin"}` and verified that the database correctly registered the user as `user` instead of `admin`.

---
*PR created automatically by Jules for task [6407035322812835758](https://jules.google.com/task/6407035322812835758) started by @jeanzinho509*