### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in image deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-28 - [Path Traversal in Image Deletion]
+**Vulnerability:** A critical path traversal vulnerability existed in `server/controllers/upload.controller.js`'s `deleteImage` endpoint. User input (`imageUrl`) was concatenated with the base directory using `path.join`, allowing malicious payloads like `../../etc/passwd` to be deleted if the backend had sufficient permissions.
+**Learning:** The previous implementation extracted a path segment from a URL and passed it directly to `path.join()`. This is inherently unsafe because `path.join()` normalizes the path but does not restrict it to a specific base directory.
+**Prevention:** Always use `path.resolve()` combined with a strict containment check to verify that the final, absolute path strictly begins with the expected base directory prefix (`resolvedBaseDir + path.sep`).

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -158,8 +158,14 @@ exports.deleteImage = async (req, res) => {
     
     // Extract file path from URL
     const urlPath = imageUrl.replace('/uploads/', '');
-    const filePath = path.join(UPLOAD_DIR, urlPath);
+    const resolvedUploadDir = path.resolve(UPLOAD_DIR);
+    const filePath = path.resolve(resolvedUploadDir, urlPath);
     
+    // Security check: Prevent directory traversal attacks
+    if (!filePath.startsWith(resolvedUploadDir + path.sep)) {
+      return res.status(403).json({ message: 'Forbidden: Invalid file path' });
+    }
+
     // Check if file exists
     if (!fs.existsSync(filePath)) {
       return res.status(404).json({ message: 'Image not found' });


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in image deletion

Severity: CRITICAL
Vulnerability: Unsanitized user input (`imageUrl`) was passed to `path.join()`, allowing directory traversal attacks (e.g., `../../`).
Impact: Attackers could potentially delete arbitrary files on the server (like `/etc/passwd`) if the Node.js process had permissions.
Fix: Replaced `path.join` with `path.resolve` and implemented a strict prefix validation check using `startsWith(resolvedBaseDir + path.sep)` to ensure the absolute target path is contained within the uploads directory.
Verification: Verified locally by starting the server and ensuring application functionality. Code review passed.

---
*PR created automatically by Jules for task [18107828693668328922](https://jules.google.com/task/18107828693668328922) started by @jeanzinho509*