### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix sensitive file exposure via static serving

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+
+## 2024-05-24 - [CRITICAL] Sensitive File Exposure via Static File Serving
+**Vulnerability:** The application was serving the entire root directory statically using `app.use(express.static(path.join(__dirname, '/')));`. This allowed attackers to request sensitive files like `.env`, `package.json`, `server.js`, and database credentials simply by browsing to them directly or using path traversal (e.g., `/%2e%2e/%2e%2e/etc/passwd` or `/.env`).
+**Learning:** Even if routing appears straightforward, serving the root directory with static middleware blindly exposes every file and folder in the application root. Attackers can bypass naive checks using URL encoding and case-insensitivity on some file systems.
+**Prevention:**
+1. Added a custom security middleware *before* the static file server to explicitly block access to sensitive files and directories.
+2. The middleware uses `decodeURIComponent(req.path)` to prevent URL-encoding bypasses (e.g., `%2e` for `.`).
+3. `path.normalize()` is used to resolve path traversals correctly and extract the true first segment of the requested path.
+4. Blocked any file/directory starting with a dot (`.`) and used a strict lowercase denylist for top-level application files (`server.js`, `database/`, etc.).

--- a/server.js
+++ b/server.js
@@ -23,6 +23,30 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// Security Middleware to prevent path traversal and exposure of sensitive files
+app.use((req, res, next) => {
+  try {
+    const decodedPath = decodeURIComponent(req.path);
+    const normalizedPath = path.normalize(decodedPath);
+
+    const denylist = [
+      'server.js', 'package.json', 'package-lock.json', 'pnpm-lock.yaml',
+      'database', 'server', 'setup.js', 'node_modules', 'readme.md'
+    ];
+
+    const segments = normalizedPath.split(/[\/\\]/).filter(Boolean);
+    const firstSegment = segments[0] ? segments[0].toLowerCase() : null;
+
+    if (firstSegment && (firstSegment.startsWith('.') || denylist.includes(firstSegment))) {
+      return res.status(403).send('Access denied');
+    }
+
+    next();
+  } catch (error) {
+    return res.status(400).send('Bad Request');
+  }
+});
+
 // Serve static files
 app.use(express.static(path.join(__dirname, '/')));
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The Express server used `app.use(express.static(path.join(__dirname, '/')));`, exposing the entire project root. This allowed anyone to access sensitive source code, configuration files (like `.env`), and node_modules.
🎯 **Impact:** An attacker could remotely download database credentials, JWT secrets, application source code, and deployment configuration, leading to full application compromise.
🔧 **Fix:** Added a custom security middleware preceding the static file handler. This middleware normalizes the requested path, explicitly blocks anything starting with a dot (`.`), and uses a strict, case-insensitive denylist to prevent top-level sensitive files (e.g., `server.js`, `database/`) from being served.
✅ **Verification:** Verified via test server that requests to `/.env`, `/%2Eenv`, and `/SERVER.JS` correctly return a `403 Forbidden` without leaking additional path details.

---
*PR created automatically by Jules for task [8748108782006917644](https://jules.google.com/task/8748108782006917644) started by @jeanzinho509*