### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in image deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [CRITICAL] Path Traversal in Image Deletion
+**Vulnerability:** The `deleteImage` endpoint in `server/controllers/upload.controller.js` used `path.join` to concatenate user-provided image URLs with the base upload directory. This allowed a path traversal attack, meaning a user could provide a URL like `/uploads/../../server.js` and delete arbitrary files on the server (like `server.js`).
+**Learning:** `path.join` does not resolve absolute paths or traverse beyond the root in a safe way for user input. It simply concatenates strings and normalizes the path. When handling file deletions based on user input, you must ensure the resolved path remains within the intended base directory.
+**Prevention:** Always use `path.resolve` to get the absolute path, and verify that the resulting absolute path starts with the expected base directory's absolute path (plus a directory separator to prevent prefix spoofing like `/uploads` vs `/uploads-backup`).

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -158,8 +158,18 @@ exports.deleteImage = async (req, res) => {
     
     // Extract file path from URL
     const urlPath = imageUrl.replace('/uploads/', '');
-    const filePath = path.join(UPLOAD_DIR, urlPath);
     
+    // Resolve the intended file path
+    const resolvedUploadDir = path.resolve(UPLOAD_DIR);
+    const filePath = path.resolve(resolvedUploadDir, urlPath);
+
+    // SECURITY: Prevent Path Traversal
+    // Ensure the resolved file path starts with the upload directory
+    if (!filePath.startsWith(resolvedUploadDir + path.sep) && filePath !== resolvedUploadDir) {
+      console.warn(`[SECURITY] Path traversal attempt detected: ${imageUrl}`);
+      return res.status(403).json({ message: 'Forbidden: Invalid file path' });
+    }
+
     // Check if file exists
     if (!fs.existsSync(filePath)) {
       return res.status(404).json({ message: 'Image not found' });


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `deleteImage` endpoint used `path.join` to concatenate user-provided image URLs with the base upload directory. This allowed a path traversal attack, where a user could provide a URL like `/uploads/../../server.js` and delete arbitrary files on the server.
🎯 Impact: An authenticated attacker could delete arbitrary files on the server.
🔧 Fix: Replaced `path.join` with `path.resolve` and added a strict containment check to ensure the resolved file path starts with the intended upload directory's absolute path.
✅ Verification: Created local test scripts to verify the fix correctly prevented directory traversal (`../`) and allowed valid paths. Documented the finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [505566149626825906](https://jules.google.com/task/505566149626825906) started by @jeanzinho509*