### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - [Path Traversal in File Manipulation Endpoints]
+**Vulnerability:** A critical path traversal vulnerability was found in `server/controllers/upload.controller.js` (`deleteImage` function) where user input (`imageUrl`) was used with `path.join()` without verification, allowing deletion of arbitrary files like `../../../../etc/passwd`.
+**Learning:** `path.join()` is insufficient for securely creating file paths with user input because it allows backward traversal using `..`.
+**Prevention:** To prevent this, resolve the absolute paths for both the base directory and the target file using `path.resolve()`. Then, use `.startsWith()` to verify that the resolved target file path resides within the bounds of the resolved base directory before performing any file system operations. Specifically, ensure the trailing slash is appended to the base directory during the check to prevent partial directory name matching.

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -158,15 +158,22 @@ exports.deleteImage = async (req, res) => {
     
     // Extract file path from URL
     const urlPath = imageUrl.replace('/uploads/', '');
-    const filePath = path.join(UPLOAD_DIR, urlPath);
+
+    // Prevent path traversal by resolving to absolute paths and verifying
+    const resolvedUploadDir = path.resolve(UPLOAD_DIR) + path.sep;
+    const resolvedFilePath = path.resolve(UPLOAD_DIR, urlPath);
+
+    if (!resolvedFilePath.startsWith(resolvedUploadDir)) {
+      return res.status(403).json({ message: 'Invalid file path' });
+    }
     
     // Check if file exists
-    if (!fs.existsSync(filePath)) {
+    if (!fs.existsSync(resolvedFilePath)) {
       return res.status(404).json({ message: 'Image not found' });
     }
     
     // Delete file
-    fs.unlinkSync(filePath);
+    fs.unlinkSync(resolvedFilePath);
     
     res.status(200).json({
       message: 'Image deleted successfully'


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `deleteImage` function in `server/controllers/upload.controller.js` used user input to construct a file path via `path.join()` without verifying whether the resulting file resided within the designated upload directory.
🎯 **Impact:** An attacker could craft an `imageUrl` payload containing directory traversal characters (`../`) to escape the upload directory and delete arbitrary files on the system, potentially causing DoS or disrupting key backend systems.
🔧 **Fix:** Replaced `path.join()` with `path.resolve()` to obtain absolute paths for both the base upload directory and the user-specified target file. Added a strict validation check utilizing `.startsWith()` and `path.sep` to definitively verify that the resolved target file resides within the resolved base upload bounds. Requests attempting to breach the boundary now safely fail with a `403` status.
✅ **Verification:** Use `pnpm start` or `node server.js` to run the application and attempt an API request to the deletion endpoint supplying a payload like `../../../../etc/passwd` to verify it gets blocked by the new security boundary check. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7409778179078044438](https://jules.google.com/task/7409778179078044438) started by @jeanzinho509*