### PR TITLE
⚡ Bolt: Shift `minRating` calculation to DB natively via `HAVING` clause to eliminate N+1 latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-30 - N+1 Query Aggregation in Node.js
+**Learning:** Found a severe performance bottleneck and pagination calculation bug in `server/controllers/product.controller.js` where `Promise.all` was used to manually aggregate subqueries (e.g. average ratings) inside Node.js after a database fetch. This pattern caused an N+1 query explosion and resulted in incorrect pagination totals since the count was incorrectly mapped on just the current paginated view.
+**Action:** Shift conditional logic and property computation to the database using SQL subqueries with `HAVING` clauses and aggregation functions. Ensure total counts are resolved dynamically using wrapped subqueries `(SELECT COUNT(*) FROM (...))` for precision, drastically improving latency and database overhead.

--- a/server/controllers/product.controller.js
+++ b/server/controllers/product.controller.js
@@ -66,32 +66,30 @@ exports.getAllProducts = async (req, res) => {
     const [products] = await pool.query(query, params);
     
     // Build count query with the same conditions
-    let countQuery = `
-      SELECT COUNT(*) as total 
-      FROM products p
-      WHERE ${conditions.join(' AND ')}
-    `;
-    
+    let countQuery;
     let countParams = [...params.slice(0, params.length - 2)]; // Remove limit and offset
     
+    if (minRating !== null) {
+      countQuery = `
+        SELECT COUNT(*) as total FROM (
+          SELECT p.id, (SELECT AVG(rating) FROM reviews r WHERE r.product_id = p.id) as average_rating
+          FROM products p
+          WHERE ${conditions.join(' AND ')}
+          HAVING average_rating >= ?
+        ) as count_query
+      `;
+      countParams.push(minRating);
+    } else {
+      countQuery = `
+        SELECT COUNT(*) as total
+        FROM products p
+        WHERE ${conditions.join(' AND ')}
+      `;
+    }
+
     // Execute count query
     const [countResult] = await pool.query(countQuery, countParams);
-    
-    // If we have a rating filter, we need to count manually
     let totalProducts = countResult[0].total;
-    
-    if (minRating !== null) {
-      // Count products that meet the rating criteria
-      const filteredProducts = await Promise.all(products.map(async (product) => {
-        const [ratingResult] = await pool.query(
-          'SELECT AVG(rating) as avg_rating FROM reviews WHERE product_id = ?',
-          [product.id]
-        );
-        return ratingResult[0].avg_rating >= minRating ? product : null;
-      }));
-      
-      totalProducts = filteredProducts.filter(p => p !== null).length;
-    }
     
     const totalPages = Math.ceil(totalProducts / limit);
     
@@ -226,32 +224,30 @@ exports.getProductsByCategory = async (req, res) => {
     const [products] = await pool.query(query, params);
     
     // Build count query with the same conditions
-    let countQuery = `
-      SELECT COUNT(*) as total 
-      FROM products p
-      WHERE ${conditions.join(' AND ')}
-    `;
-    
+    let countQuery;
     let countParams = [...params.slice(0, params.length - 2)]; // Remove limit and offset
     
+    if (minRating !== null) {
+      countQuery = `
+        SELECT COUNT(*) as total FROM (
+          SELECT p.id, (SELECT AVG(rating) FROM reviews r WHERE r.product_id = p.id) as average_rating
+          FROM products p
+          WHERE ${conditions.join(' AND ')}
+          HAVING average_rating >= ?
+        ) as count_query
+      `;
+      countParams.push(minRating);
+    } else {
+      countQuery = `
+        SELECT COUNT(*) as total
+        FROM products p
+        WHERE ${conditions.join(' AND ')}
+      `;
+    }
+
     // Execute count query
     const [countResult] = await pool.query(countQuery, countParams);
-    
-    // If we have a rating filter, we need to count manually
     let totalProducts = countResult[0].total;
-    
-    if (minRating !== null) {
-      // Count products that meet the rating criteria
-      const filteredProducts = await Promise.all(products.map(async (product) => {
-        const [ratingResult] = await pool.query(
-          'SELECT AVG(rating) as avg_rating FROM reviews WHERE product_id = ?',
-          [product.id]
-        );
-        return ratingResult[0].avg_rating >= minRating ? product : null;
-      }));
-      
-      totalProducts = filteredProducts.filter(p => p !== null).length;
-    }
     
     const totalPages = Math.ceil(totalProducts / limit);
     
@@ -347,33 +343,32 @@ exports.searchProducts = async (req, res) => {
     const [products] = await pool.query(query, params);
     
     // Build count query with the same conditions
-    let countQuery = `
-      SELECT COUNT(*) as total 
-      FROM products p
-      LEFT JOIN categories c ON p.category_id = c.id
-      WHERE ${conditions.join(' AND ')}
-    `;
-    
+    let countQuery;
     let countParams = [...params.slice(0, params.length - 2)]; // Remove limit and offset
     
+    if (minRating !== null) {
+      countQuery = `
+        SELECT COUNT(*) as total FROM (
+          SELECT p.id, (SELECT AVG(rating) FROM reviews r WHERE r.product_id = p.id) as average_rating
+          FROM products p
+          LEFT JOIN categories c ON p.category_id = c.id
+          WHERE ${conditions.join(' AND ')}
+          HAVING average_rating >= ?
+        ) as count_query
+      `;
+      countParams.push(minRating);
+    } else {
+      countQuery = `
+        SELECT COUNT(*) as total
+        FROM products p
+        LEFT JOIN categories c ON p.category_id = c.id
+        WHERE ${conditions.join(' AND ')}
+      `;
+    }
+
     // Execute count query
     const [countResult] = await pool.query(countQuery, countParams);
-    
-    // If we have a rating filter, we need to count manually
     let totalProducts = countResult[0].total;
-    
-    if (minRating !== null) {
-      // Count products that meet the rating criteria
-      const filteredProducts = await Promise.all(products.map(async (product) => {
-        const [ratingResult] = await pool.query(
-          'SELECT AVG(rating) as avg_rating FROM reviews WHERE product_id = ?',
-          [product.id]
-        );
-        return ratingResult[0].avg_rating >= minRating ? product : null;
-      }));
-      
-      totalProducts = filteredProducts.filter(p => p !== null).length;
-    }
     
     const totalPages = Math.ceil(totalProducts / limit);
     


### PR DESCRIPTION
💡 **What**: Removed nested `Promise.all` mapping inside product controllers and pushed the `average_rating` aggregation down to the MySQL layer natively.
🎯 **Why**: The original implementation fetched a paginated list of items, but then iterated to query the database individually N times. This created an N+1 scaling bottleneck and caused the `totalPages` computation to be intrinsically flawed since it counted the active subset rather than total db matches.
📊 **Impact**: Expected reduction of queries per HTTP request from N+1 (e.g. 11 queries per 10-item page) down to exactly 2 queries. Total pagination accurately represents backend inventory length.
🔬 **Measurement**: Start the server and query `/api/products?min_rating=4` locally. The endpoint will now issue purely SQL-bound checks returning correct JSON properties rather than relying on sequential mapping.

---
*PR created automatically by Jules for task [12480137347897552639](https://jules.google.com/task/12480137347897552639) started by @jeanzinho509*