### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in image deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-30 - [CRITICAL] Path Traversal in Image Deletion
+**Vulnerability:** The `deleteImage` function in `server/controllers/upload.controller.js` extracted the URL path from `imageUrl` by simply replacing `/uploads/` and joining it with the `UPLOAD_DIR`. It did not use `path.resolve` or boundary checking, allowing attackers to delete arbitrary files on the server using `../` sequences in the `imageUrl` payload.
+**Learning:** The simple usage of `path.join(UPLOAD_DIR, urlPath)` does not prevent a path traversal attack if `urlPath` contains `../`. The Node.js `path.join` resolves `../` normally without boundary limits, leading to path traversal outside of the target directory.
+**Prevention:** Always use `path.resolve` combined with boundary checking (e.g., `resolvedPath.startsWith(path.resolve(UPLOAD_DIR) + path.sep)`) when working with user-controlled input intended for file system operations.

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -158,15 +158,22 @@ exports.deleteImage = async (req, res) => {
     
     // Extract file path from URL
     const urlPath = imageUrl.replace('/uploads/', '');
-    const filePath = path.join(UPLOAD_DIR, urlPath);
+
+    // Use path.resolve to get the absolute path and prevent path traversal
+    const resolvedPath = path.resolve(UPLOAD_DIR, urlPath);
+
+    // Ensure the resolved path stays within the UPLOAD_DIR boundary
+    if (!resolvedPath.startsWith(path.resolve(UPLOAD_DIR) + path.sep)) {
+      return res.status(403).json({ message: 'Invalid image path' });
+    }
     
     // Check if file exists
-    if (!fs.existsSync(filePath)) {
+    if (!fs.existsSync(resolvedPath)) {
       return res.status(404).json({ message: 'Image not found' });
     }
     
     // Delete file
-    fs.unlinkSync(filePath);
+    fs.unlinkSync(resolvedPath);
     
     res.status(200).json({
       message: 'Image deleted successfully'


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `deleteImage` function extracted the URL path by simply replacing `/uploads/` and joining it with `UPLOAD_DIR`. Attackers could exploit this using `../` to delete arbitrary files on the server (Path Traversal).
🎯 Impact: An attacker could bypass directory restrictions to delete sensitive files (e.g., config files, DB schemas, server scripts) causing a Denial of Service or further exploitation.
🔧 Fix: Implemented Node.js `path.resolve()` with rigorous boundary checking (ensuring the resolved path starts with `path.resolve(UPLOAD_DIR) + path.sep`) before unlinking.
✅ Verification: Review the `deleteImage` function to see that `fs.unlinkSync` now operates only on constrained, absolute paths. Check `.jules/sentinel.md` for journal logs.

---
*PR created automatically by Jules for task [3034032703914700359](https://jules.google.com/task/3034032703914700359) started by @jeanzinho509*