### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix mass assignment privilege escalation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-10 - [Mass Assignment Privilege Escalation in Open Registration]
+**Vulnerability:** The open registration endpoint (`/api/auth/register`) destructured `role` directly from `req.body` and inserted it into the user creation database query. This allowed unauthenticated attackers to elevate their privileges to 'admin' simply by supplying `"role": "admin"` in the JSON payload during account creation.
+**Learning:** Destructuring request bodies without explicit allowlists or omitting sensitive fields exposes endpoints to mass assignment attacks. In registration flows, user roles should never be taken directly from the client.
+**Prevention:** Hardcode default user roles for public registration endpoints. For endpoints that require dynamic role assignment, verify the requesting user's authorization level first (e.g., ensure the requestor is already an 'admin') before applying the role. Always explicitly select only the fields needed from `req.body`.

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -20,7 +20,8 @@ const sendPasswordResetEmail = (email, token) => {
 // Register a new user
 exports.register = async (req, res) => {
   try {
-    const { name, email, password, phone, role } = req.body;
+    // 🛡️ Security enhancement: Prevent mass assignment by not destructing 'role'
+    const { name, email, password, phone } = req.body;
     
     // Validate input
     if (!name || !email || !password) {
@@ -38,8 +39,8 @@ exports.register = async (req, res) => {
     const salt = await bcrypt.genSalt(10);
     const hashedPassword = await bcrypt.hash(password, salt);
     
-    // Set default role to 'user' unless specified and user is authorized
-    const userRole = role || 'user';
+    // Set default role to 'user' to prevent privilege escalation via mass assignment
+    const userRole = 'user';
     
     // Insert user into database
     const [result] = await pool.query(


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Mass assignment in the user registration endpoint allowed unauthenticated users to inject arbitrary roles (e.g., "admin") by passing `"role": "admin"` in the JSON payload.
🎯 Impact: Attackers could freely register new administrative accounts and hijack the platform's access controls.
🔧 Fix: Removed `role` from the request body destructuring in `server/controllers/auth.controller.js` and hardcoded `userRole = 'user'`.
✅ Verification: Ran a `curl` POST request to `/api/auth/register` with `"role": "admin"`. Server response now rightfully returns `{"role": "user"}`.
Also documented this mass assignment learning in `.jules/sentinel.md` as per system prompt guidelines.

---
*PR created automatically by Jules for task [1170340287967431654](https://jules.google.com/task/1170340287967431654) started by @jeanzinho509*