### PR TITLE
🎨 Palette: Add contrasting focus indicators for keyboard navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-13 - Contrasting Focus Indicators on Colored Regions
+**Learning:** When adding global `:focus-visible` styles to an application with distinct colored regions (like a blue navbar with `#256AF5` background), the default focus outline (which is often the same brand color) becomes invisible on these regions.
+**Action:** Always verify focus indicator contrast against the background it appears on. Add specific overrides (e.g., `.navbar *:focus-visible { outline: 3px solid white; }`) to ensure keyboard navigability remains accessible across all thematic sections of the site.

--- a/style.css
+++ b/style.css
@@ -3,6 +3,16 @@
   box-sizing: border-box;
 }
 
+/* Accessibility: Focus visible styles */
+*:focus-visible {
+  outline: 3px solid #256AF5;
+  outline-offset: 2px;
+}
+
+.navbar *:focus-visible {
+  outline: 3px solid white;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 0;


### PR DESCRIPTION
💡 **What:** Added global `:focus-visible` CSS rules, including a high-contrast white override specifically for the `.navbar`.
🎯 **Why:** To ensure the interface is accessible via keyboard navigation, giving clear visual feedback of the currently focused interactive element. The white outline is necessary for elements against the blue navbar background to ensure sufficient contrast.
📸 **Before/After:** Elements now show a 3px outline when focused via keyboard (tabbing).
♿ **Accessibility:** Greatly improves keyboard navigability and WCAG contrast compliance for focus states.

---
*PR created automatically by Jules for task [12421246929787845071](https://jules.google.com/task/12421246929787845071) started by @jeanzinho509*