### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Image Deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - [Critical] Fix Path Traversal in Image Deletion
+**Vulnerability:** A critical Path Traversal vulnerability in `server/controllers/upload.controller.js` (`deleteImage` endpoint).
+**Learning:** It existed because `path.join()` was used with user input (`imageUrl` from req.body) directly without properly validating that the resulting file path stays within the intended `UPLOAD_DIR`.
+**Prevention:** To prevent this, always use `path.resolve()` on user input to resolve any relative path components (`../`) and then ensure the path strictly starts with the designated boundary path (`path.resolve(UPLOAD_DIR) + path.sep`) using `.startsWith()`.

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -160,13 +160,19 @@ exports.deleteImage = async (req, res) => {
     const urlPath = imageUrl.replace('/uploads/', '');
     const filePath = path.join(UPLOAD_DIR, urlPath);
     
+    // Prevent path traversal
+    const resolvedPath = path.resolve(filePath);
+    if (!resolvedPath.startsWith(path.resolve(UPLOAD_DIR) + path.sep)) {
+      return res.status(403).json({ message: 'Forbidden path' });
+    }
+
     // Check if file exists
-    if (!fs.existsSync(filePath)) {
+    if (!fs.existsSync(resolvedPath)) {
       return res.status(404).json({ message: 'Image not found' });
     }
     
     // Delete file
-    fs.unlinkSync(filePath);
+    fs.unlinkSync(resolvedPath);
     
     res.status(200).json({
       message: 'Image deleted successfully'


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A path traversal vulnerability existed in the `deleteImage` endpoint (`server/controllers/upload.controller.js`). `path.join()` was used on unsanitized user input (`imageUrl`), allowing a malicious user to craft a path that navigates outside `UPLOAD_DIR` and deletes arbitrary files on the server.
🎯 Impact: Complete system compromise or data loss by deleting sensitive system or application files.
🔧 Fix: Resolved the provided path using `path.resolve()` and explicitly verified that it strictly starts with the base directory (`path.resolve(UPLOAD_DIR) + path.sep`) before checking existence and deleting.
✅ Verification: Code logic confirmed. Journal entry recorded.

Also added `.jules/sentinel.md` journal entry.

---
*PR created automatically by Jules for task [14897508437229369098](https://jules.google.com/task/14897508437229369098) started by @jeanzinho509*